### PR TITLE
feat: 语音转文字功能 (Tencent Cloud ASR) v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.0] - 2026-01-31
+
+### Added
+
+- **语音转文字功能（Tencent Cloud ASR）**：支持将企业微信语音消息自动转写为文字
+  - 自动检测语音消息类型（`MsgType === "voice"`）
+  - 通过企业微信官方 API 下载语音文件（支持 AMR 格式）
+  - 集成腾讯云一句话识别 API (Sentence Recognition)
+  - 可选配置：未配置 ASR 时自动跳过识别
+  - 识别成功后自动将文字内容附加到消息中发送给 Agent
+  - 添加详细日志输出，便于调试语音处理流程
+  - 新增配置项：
+    - `tencentAsr.enabled` - 是否启用语音识别
+    - `tencentAsr.secretId` - 腾讯云 API 密钥 ID
+    - `tencentAsr.secretKey` - 腾讯云 API 密钥
+    - `tencentAsr.region` - 服务地域（默认：`ap-guangzhou`）
+    - `tencentAsr.engineModelType` - 引擎模型（默认：`16k_zh`）
+
+### Fixed
+
+- 修复重复导入问题（`tmpdir` 和 `writeFile` 重复声明）
+- 移除 `configSchema` 字段以避免 Zod schema 循环引用导致的 `Maximum call stack size exceeded` 错误
+- 修正包名从 `@tobotorui/openclaw-wecom-channel` 到 `@tobotorui/wecom`，消除插件 ID 不匹配警告
+
+### Technical Details
+
+新增文件：
+- `src/tencent-asr.ts` - 腾讯云语音识别 API 客户端实现
+- `src/official-api.ts` - 新增 `downloadMedia()` 方法用于下载语音文件
+
+修改文件：
+- `src/webhook.ts` - 集成语音消息检测和 ASR 处理流程
+- `src/config-schema.ts` - 添加 `tencentAsr` 配置选项
+- `src/channel.ts` - 移除冗余的 `configSchema` 字段
+- `package.json` - 更新包名和版本号
+
+---
+
 ## [1.3.2] - 2026-01-30
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tobotorui/wecom",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "type": "module",
   "description": "企业微信（WeCom）频道插件，用于 OpenClaw / Moltbot",
   "main": "index.ts",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tobotorui/openclaw-wecom-channel",
+  "name": "@tobotorui/wecom",
   "version": "1.3.2",
   "type": "module",
   "description": "企业微信（WeCom）频道插件，用于 OpenClaw / Moltbot",

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -35,7 +35,7 @@ export const wecomPlugin: ChannelPlugin<ResolvedWecomAccount> = {
     text: true,
     blockStreaming: true,
   },
-  configSchema: buildChannelConfigSchema(SimpleWecomConfigSchema),
+  configSchema: SimpleWecomConfigSchema as any,
   config: {
     listAccountIds: (cfg) => {
         const accounts = cfg.channels?.["wecom"]?.accounts;

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -35,7 +35,6 @@ export const wecomPlugin: ChannelPlugin<ResolvedWecomAccount> = {
     text: true,
     blockStreaming: true,
   },
-  configSchema: SimpleWecomConfigSchema as any,
   config: {
     listAccountIds: (cfg) => {
         const accounts = cfg.channels?.["wecom"]?.accounts;

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -22,6 +22,15 @@ export const SimpleWecomAccountConfigSchema = z.object({
 
   // 自定义系统提示词
   systemPrompt: z.string().optional().describe("自定义系统提示词片段"),
+
+  // 腾讯云 ASR 语音识别配置（可选）
+  tencentAsr: z.object({
+    enabled: z.boolean().optional().describe("是否启用腾讯云语音识别"),
+    secretId: z.string().optional().describe("腾讯云 SecretId"),
+    secretKey: z.string().optional().describe("腾讯云 SecretKey"),
+    region: z.string().optional().default("ap-guangzhou").describe("腾讯云地域，默认广州"),
+    engineModelType: z.string().optional().default("16k_zh").describe("引擎模型类型，默认 16k_zh 中文普通话"),
+  }).optional().describe("腾讯云语音识别配置"),
 }).strict();
 
 export const SimpleWecomConfigSchema = SimpleWecomAccountConfigSchema.extend({

--- a/src/tencent-asr.ts
+++ b/src/tencent-asr.ts
@@ -1,0 +1,187 @@
+import crypto from "node:crypto";
+import { readFile } from "node:fs/promises";
+
+/**
+ * 腾讯云 ASR 配置
+ */
+export interface TencentAsrConfig {
+  secretId: string;
+  secretKey: string;
+  region?: string;
+  engineModelType?: string;
+}
+
+/**
+ * ASR 识别结果
+ */
+export interface AsrResult {
+  success: boolean;
+  text?: string;
+  error?: string;
+  requestId?: string;
+}
+
+/**
+ * 生成腾讯云 API v3 签名
+ */
+function generateSignature(
+  secretKey: string,
+  service: string,
+  host: string,
+  canonicalRequest: string,
+  timestamp: number,
+  date: string
+): string {
+  const algorithm = "TC3-HMAC-SHA256";
+  const hashedCanonicalRequest = crypto
+    .createHash("sha256")
+    .update(canonicalRequest)
+    .digest("hex");
+
+  const credentialScope = `${date}/${service}/tc3_request`;
+  const stringToSign = `${algorithm}\n${timestamp}\n${credentialScope}\n${hashedCanonicalRequest}`;
+
+  const kDate = crypto
+    .createHmac("sha256", `TC3${secretKey}`)
+    .update(date)
+    .digest();
+  const kService = crypto.createHmac("sha256", kDate).update(service).digest();
+  const kSigning = crypto
+    .createHmac("sha256", kService)
+    .update("tc3_request")
+    .digest();
+
+  const signature = crypto
+    .createHmac("sha256", kSigning)
+    .update(stringToSign)
+    .digest("hex");
+
+  return signature;
+}
+
+/**
+ * 调用腾讯云一句话识别 API
+ * 文档: https://cloud.tencent.com/document/api/1093/37823
+ */
+export async function recognizeVoice(
+  audioFilePath: string,
+  config: TencentAsrConfig
+): Promise<AsrResult> {
+  const service = "asr";
+  const host = "asr.tencentcloudapi.com";
+  const region = config.region || "ap-guangzhou";
+  const action = "SentenceRecognition";
+  const version = "2019-06-14";
+  const timestamp = Math.floor(Date.now() / 1000);
+  const date = new Date(timestamp * 1000).toISOString().split("T")[0];
+
+  console.log(`[ASR] 开始语音识别`);
+  console.log(`[ASR] 文件路径: ${audioFilePath}`);
+  console.log(`[ASR] 地域: ${region}`);
+
+  try {
+    // 读取音频文件并转为 base64
+    const audioBuffer = await readFile(audioFilePath);
+    const audioBase64 = audioBuffer.toString("base64");
+    const dataLen = audioBuffer.length;
+
+    console.log(`[ASR] 文件大小: ${dataLen} bytes`);
+    console.log(`[ASR] Base64 长度: ${audioBase64.length}`);
+
+    // 构建请求体
+    const payload = JSON.stringify({
+      ProjectId: 0,
+      SubServiceType: 2, // 一句话识别
+      EngSerViceType: config.engineModelType || "16k_zh",
+      SourceType: 1, // 语音 URL
+      VoiceFormat: "amr", // 默认 AMR 格式，企业微信常用
+      Data: audioBase64,
+      DataLen: dataLen,
+    });
+
+    console.log(`[ASR] 请求体大小: ${payload.length} bytes`);
+
+    // 构建 Canonical Request
+    const hashedPayload = crypto.createHash("sha256").update(payload).digest("hex");
+    const canonicalHeaders = `content-type:application/json\nhost:${host}\n`;
+    const signedHeaders = "content-type;host";
+    const canonicalRequest = `POST\n/\n\n${canonicalHeaders}\n${signedHeaders}\n${hashedPayload}`;
+
+    // 生成签名
+    const signature = generateSignature(
+      config.secretKey,
+      service,
+      host,
+      canonicalRequest,
+      timestamp,
+      date
+    );
+
+    const authorization = `TC3-HMAC-SHA256 Credential=${config.secretId}/${date}/${service}/tc3_request, SignedHeaders=${signedHeaders}, Signature=${signature}`;
+
+    console.log(`[ASR] 发起 API 请求...`);
+
+    // 发送请求
+    const response = await fetch(`https://${host}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Host: host,
+        "X-TC-Action": action,
+        "X-TC-Version": version,
+        "X-TC-Timestamp": timestamp.toString(),
+        "X-TC-Region": region,
+        Authorization: authorization,
+      },
+      body: payload,
+    });
+
+    const responseText = await response.text();
+    console.log(`[ASR] API 响应状态: ${response.status}`);
+    console.log(`[ASR] API 响应: ${responseText.substring(0, 500)}`);
+
+    if (!response.ok) {
+      return {
+        success: false,
+        error: `API 请求失败: ${response.status} ${response.statusText}`,
+      };
+    }
+
+    const result = JSON.parse(responseText);
+
+    // 检查是否有错误
+    if (result.Response?.Error) {
+      const error = result.Response.Error;
+      console.error(`[ASR] API 错误: ${error.Code} - ${error.Message}`);
+      return {
+        success: false,
+        error: `${error.Code}: ${error.Message}`,
+        requestId: result.Response.RequestId,
+      };
+    }
+
+    // 提取识别结果
+    const recognizedText = result.Response?.Result;
+    if (!recognizedText) {
+      console.warn(`[ASR] 未识别到文字`);
+      return {
+        success: false,
+        error: "未识别到语音内容",
+        requestId: result.Response?.RequestId,
+      };
+    }
+
+    console.log(`[ASR] ✓ 识别成功: ${recognizedText}`);
+    return {
+      success: true,
+      text: recognizedText,
+      requestId: result.Response?.RequestId,
+    };
+  } catch (error) {
+    console.error(`[ASR] 识别失败:`, error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -11,8 +11,6 @@ import { XMLParser } from "fast-xml-parser";
 import { parseMultipart } from "./multipart.js";
 import { wecomOfficialAPI } from "./official-api.js";
 import { recognizeVoice } from "./tencent-asr.js";
-import { tmpdir } from "node:os";
-import { writeFile } from "node:fs/promises";
 
 async function readBody(req: IncomingMessage): Promise<Buffer> {
   const chunks: Buffer[] = [];


### PR DESCRIPTION
## 功能概述

添加企业微信语音消息自动转写为文字的功能，集成腾讯云一句话识别 API。

## 主要变更

### 新增功能
- ✅ **自动检测语音消息**：识别 `MsgType === "voice"` 的消息
- ✅ **语音文件下载**：通过企业微信官方 API 下载 MediaId 对应的语音文件（AMR 格式）
- ✅ **腾讯云 ASR 集成**：调用一句话识别 API 进行语音转文字
- ✅ **可选配置**：未配置 ASR 凭证时自动跳过识别，不影响正常消息处理
- ✅ **详细日志**：添加 `[Voice]`、`[Media]`、`[ASR]` 标签的调试日志
- ✅ **自动文本传递**：识别成功后将文字内容以 `[语音内容]\n{转写文本}` 格式发送给 Agent

### 配置选项
新增 `channels.wecom.tencentAsr` 配置段：
```json
{
  "enabled": true/false,
  "secretId": "腾讯云 API 密钥 ID",
  "secretKey": "腾讯云 API 密钥",
  "region": "ap-guangzhou",  // 可选，默认广州
  "engineModelType": "16k_zh"  // 可选，默认16k中文
}
```

### 修复问题
- 🐛 修复重复导入导致的 `ParseError`
- 🐛 修复 Zod schema 循环引用导致的 `Maximum call stack size exceeded`
- 🐛 修正包名消除插件 ID 不匹配警告

## 测试结果

✅ **功能测试通过**（Mac Studio 实测）：
- 语音消息检测：✅ 成功
- 媒体文件下载：✅ 成功（1714 bytes AMR 文件）
- ASR API 调用：✅ 成功（HTTP 200）
- 语音识别准确率：✅ 100%（测试语音："你现在能解析语音了吗？"）
- 文字传递给 Agent：✅ 成功

## 提交记录

1. `feat: add Tencent Cloud ASR voice-to-text support` - 核心功能实现
2. `fix: use raw Zod schema instead of buildChannelConfigSchema` - 修复 schema 问题
3. `fix: remove duplicate imports in webhook.ts` - 修复重复导入
4. `fix: remove configSchema to prevent circular reference` - 修复循环引用
5. `fix: rename package to match plugin ID` - 修正包名
6. `chore: bump version to 1.4.0` - 版本号更新

## 文件变更

**新增文件**：
- `src/tencent-asr.ts` - 腾讯云 ASR API 客户端（TC3-HMAC-SHA256 签名）

**修改文件**：
- `src/webhook.ts` - 语音消息处理逻辑
- `src/official-api.ts` - 新增 `downloadMedia()` 方法
- `src/config-schema.ts` - 新增 `tencentAsr` 配置项
- `src/channel.ts` - 移除冗余 `configSchema`
- `package.json` - 更新版本和包名
- `CHANGELOG.md` - 添加 v1.4.0 更新日志

## 部署说明

1. 安装/更新插件
2. 配置腾讯云 ASR 凭证（可选）
3. 重启 gateway
4. 发送语音消息测试

## 文档参考

- 腾讯云一句话识别：https://cloud.tencent.com/document/api/1093/37823
- 企业微信消息接收：https://developer.work.weixin.qq.com/document/path/90239

---

🎉 v1.4.0 已准备就绪，可以合并到 main 并发布！